### PR TITLE
Add better support for replicates using silhouette score permutation test

### DIFF
--- a/d3pendr/d3pendr.py
+++ b/d3pendr/d3pendr.py
@@ -5,7 +5,7 @@ from statsmodels.stats.multitest import multipletests
 from joblib import Parallel, delayed
 
 from .multibam import MultiBamParser, MultiBigWigParser, bam_or_bw
-from .gtf import gtf_iterator, chunk_gtf_records, GTFRecord
+from .gtf import GTFGeneBoundaryIterator, chunk_gtf_records, GTFRecord
 from .tpe import get_tpe_distribution
 from .stats import d3pendr_stats, WassTestResults
 
@@ -64,7 +64,7 @@ def _process_gtf_records(gtf_records, bam_opts, stat_opts, random_seed, is_bam):
 def run_d3pendr(opts):
 
     filetype = bam_or_bw(*opts.bam.treatment_fns, *opts.bam.control_fns)
-    gtf_it = gtf_iterator(**dataclasses.asdict(opts.gtf))
+    gtf_it = GTFGeneBoundaryIterator(**dataclasses.asdict(opts.gtf))
     if opts.processes == 1:
         # run on main process
         results, tpa_apa_results = _process_gtf_records(

--- a/d3pendr/d3pendr.py
+++ b/d3pendr/d3pendr.py
@@ -1,152 +1,84 @@
+import dataclasses
 import numpy as np
 import pandas as pd
 from statsmodels.stats.multitest import multipletests
 from joblib import Parallel, delayed
 
 from .multibam import MultiBamParser, MultiBigWigParser, bam_or_bw
-from .gtf import gtf_iterator, chunk_gtf_records
-from .tpe import get_tpe_distribution, get_apa_tpes
-from .stats import d3pendr_stats
+from .gtf import gtf_iterator, chunk_gtf_records, GTFRecord
+from .tpe import get_tpe_distribution
+from .stats import d3pendr_stats, WassTestResults
 
 
-# columns in the output bed format
-RESULTS_COLUMNS = [
-    'chrom', 'start', 'end', 'gene_id', 'score', 'strand',
-    'wass_dist', 'wass_dir', 'wass_pval', 'wass_fdr',
-    'sil_score', 'sil_pval', 'sil_fdr',
-    'nreads_cntrl', 'nreads_treat'
-]
+@dataclasses.dataclass
+class D3pendrResults(WassTestResults, GTFRecord):
+    '''class for handling all d3pendr results for a record'''
 
-TPE_APA_RESULTS_COLUMNS = [
-    'chrom', 'start', 'end', 'gene_id', 'strand',
-    'nreads_cntrl', 'nreads_treat',
-    'frac_cntrl', 'frac_treat', 'relative_change'
-]
-        
+    @staticmethod
+    def from_records(gtf_record, wasstest_results):
+        return D3pendrResults(
+            **dataclasses.asdict(gtf_record),
+            **dataclasses.asdict(wasstest_results)
+        )
 
-def _process_gtf_records(gtf_records, treat_bam_fns, cntrl_bam_fns,
-                         read_strand, read_end, paired_end_read,
-                         min_read_overlap, min_reads,
-                         bootstraps, threshold, fit_gamma,
-                         sil_test, fit_skewnorm, random_state,
-                         is_bam, find_apa_tpe_sites, tpe_sigma,
-                         tpe_min_reads, tpe_min_rel_change):
 
-    random_state = np.random.default_rng(random_state)
+def _process_gtf_records(gtf_records, bam_opts, stat_opts, random_seed, is_bam):
+
+    random_state = np.random.default_rng(random_seed)
     results = []
     tpe_apa_res = []
 
     parser = MultiBamParser if is_bam else MultiBigWigParser
 
-    with parser(cntrl_bam_fns) as cntrl_bam, parser(treat_bam_fns) as treat_bam:
+    with parser(bam_opts.control_fns) as cntrl_bam, parser(bam_opts.treatment_fns) as treat_bam:
 
-        for chrom, start, end, gene_id, strand in gtf_records:
+        for record in gtf_records:
             cntrl_distribs, nreads_cntrl = get_tpe_distribution(
-                cntrl_bam, chrom, start, end, strand,
-                min_read_overlap, read_strand, read_end,
-                paired_end_read, is_bam
+                cntrl_bam,
+                record.chrom, record.start, record.end, record.strand,
+                bam_opts.min_read_overlap,
+                bam_opts.read_strand, bam_opts.read_end,
+                bam_opts.paired_end_read, is_bam
             )
             treat_distribs, nreads_treat = get_tpe_distribution(
-                treat_bam, chrom, start, end, strand,
-                min_read_overlap, read_strand, read_end,
-                paired_end_read, is_bam
+                treat_bam,
+                record.chrom, record.start, record.end, record.strand,
+                bam_opts.min_read_overlap,
+                bam_opts.read_strand, bam_opts.read_end,
+                bam_opts.paired_end_read, is_bam
             )
 
+            min_reads = bam_opts.min_reads_per_rep
             if (nreads_cntrl >= min_reads).all() and (nreads_treat >= min_reads).all():
-                wass_dist, wass_dir, wass_pval, sil_score, sil_pval = d3pendr_stats(
+                wass_res = d3pendr_stats(
                     cntrl_distribs, treat_distribs,
-                    bootstraps=bootstraps, fit_gamma=fit_gamma,
-                    sil_test=sil_test, fit_skewnorm=fit_skewnorm,
-                    random_state=random_state
+                    random_state=random_state,
+                    **dataclasses.asdict(stat_opts)
                 )
-                results.append([
-                    chrom, start, end, gene_id, round(wass_dist), strand,
-                    wass_dist, wass_dir, wass_pval, 1, # placeholder for wasserstein test fdr
-                    sil_score, sil_pval, 1,
-                    nreads_cntrl, nreads_treat
-                ])
+                results.append(D3pendrResults.from_records(record, wass_res))
 
-                if find_apa_tpe_sites and wass_pval <= threshold:
-                    tpes = get_apa_tpes(
-                        cntrl_distribs, sum(nreads_cntrl),
-                        treat_distribs, sum(nreads_treat),
-                        tpe_sigma, tpe_min_reads, tpe_min_rel_change
-                    )
-                    for t in tpes:
-                        tpe_start, tpe_end, *res = t
-                        # revert tpe coords to absolute
-                        if strand == '+':
-                            tpe_start = tpe_start + start
-                            tpe_end = tpe_end + start
-                        elif strand == '-':
-                            tpe_start, tpe_end = tpe_end, tpe_start
-                            tpe_start = end - tpe_start
-                            tpe_end = end - tpe_end
-
-                        tpe_apa_res.append([
-                            chrom, tpe_start, tpe_end, gene_id, strand, *res
-                        ])
-
-    results = pd.DataFrame(results, columns=RESULTS_COLUMNS)
-
-    if find_apa_tpe_sites:
-        tpe_apa_res = pd.DataFrame(tpe_apa_res, columns=TPE_APA_RESULTS_COLUMNS)
-    else:
-        tpe_apa_res = None
-    return results, tpe_apa_res
+    results = pd.DataFrame(results)
+    return results
 
 
-def run_d3pendr(gtf_fn, treat_bam_fns, cntrl_bam_fns,
-                read_strand, read_end, paired_end_read,
-                min_read_overlap, min_reads_per_cond,
-                extend_gene_five_prime, use_5utr,
-                extend_gene_three_prime,
-                by_locus,
-                max_terminal_intron_size,
-                min_terminal_exon_size,
-                bootstraps, threshold,
-                fit_gamma, sil_test, fit_skewnorm,
-                find_tpe_sites, tpe_sigma,
-                tpe_min_reads, tpe_min_rel_change,
-                processes, random_state):
+def run_d3pendr(opts):
 
-    filetype = bam_or_bw(*treat_bam_fns, *cntrl_bam_fns)
-
-    args = (
-        treat_bam_fns, cntrl_bam_fns,
-        read_strand, read_end, paired_end_read,
-        min_read_overlap, min_reads_per_cond,
-        bootstraps, threshold, fit_gamma,
-        sil_test, fit_skewnorm, random_state,
-        filetype, find_tpe_sites, tpe_sigma,
-        tpe_min_reads, tpe_min_rel_change,
-    )
-    gtf_it = gtf_iterator(
-        gtf_fn, extend_gene_five_prime, use_5utr, extend_gene_three_prime,
-        by_locus, max_terminal_intron_size, min_terminal_exon_size,
-    )
-    if processes == 1:
+    filetype = bam_or_bw(*opts.bam.treatment_fns, *opts.bam.control_fns)
+    gtf_it = gtf_iterator(**dataclasses.asdict(opts.gtf))
+    if opts.processes == 1:
         # run on main process
         results, tpa_apa_results = _process_gtf_records(
-            gtf_it, *args
+            gtf_it, opts.bam, opts.stats, opts.random_seed, filetype
         )
     else:
-        results = Parallel(n_jobs=processes)(
-            delayed(_process_gtf_records)(gtf_chunk, *args)
-            for gtf_chunk in chunk_gtf_records(gtf_it, processes)
+        results = Parallel(n_jobs=opts.processes)(
+            delayed(_process_gtf_records)(
+                gtf_chunk, opts.bam, opts.stats, opts.random_seed, filetype
+            ) for gtf_chunk in chunk_gtf_records(gtf_it, opts.processes)
         )
-        results, tpe_apa_results = zip(*results)
         results = pd.concat(results)
-        if find_tpe_sites:
-            tpe_apa_results = pd.concat(tpe_apa_results)
-        else:
-            tpe_apa_results = None
 
     _, results['wass_fdr'], *_ = multipletests(results.wass_pval, method='fdr_bh')
     _, results['sil_fdr'], *_ = multipletests(results.sil_pval, method='fdr_bh')
 
-    if find_tpe_sites:
-        tpe_apa_results = tpe_apa_results[
-            tpe_apa_results.gene_id.isin(results.query(f'wass_fdr <= {threshold}').gene_id)
-        ]
-    return results, tpe_apa_results
+    return results

--- a/d3pendr/main.py
+++ b/d3pendr/main.py
@@ -19,9 +19,9 @@ class BAMOpts:
 class GTFOpts:
     annotation_gtf_fn: str
     extend_gene_five_prime: int
-    use_5utr: bool
     extend_gene_three_prime: int
     use_locus_tag: bool
+    allow_overlap_next_gene: bool
 
 
 @dataclasses.dataclass
@@ -84,9 +84,9 @@ def make_dataclass_decorator(dc):
 @click.option('--min-read-overlap', default=0.2)
 @click.option('--min-reads-per-rep', default=5)
 @click.option('--extend-gene-five-prime', default=0)
-@click.option('--use-5utr/--ignore-5utr', default=True)
 @click.option('--extend-gene-three-prime', default=0)
 @click.option('--use-locus-tag/--use-gene-id-tag', default=False)
+@click.option('--allow-overlap-next-gene/--no-gene-overlap', default=False)
 @click.option('--bootstraps', default=999)
 @click.option('--threshold', default=0.05)
 @click.option('--wass-fit-gamma/--no-fit-gamma', default=True)

--- a/d3pendr/main.py
+++ b/d3pendr/main.py
@@ -26,12 +26,14 @@ from .d3pendr import run_d3pendr
 @click.option('--min-terminal-exon-size', default=30)
 @click.option('--bootstraps', default=999)
 @click.option('--threshold', default=0.05)
-@click.option('--use-gamma-model/--no-model', default=True)
-@click.option('--test-homogeneity/--no-test-homogeneity', default=False)
+@click.option('--use-gamma-model/--no-gamma-model', default=True)
+@click.option('--test-homogeneity/--no-test-homogeneity', default=True)
+@click.option('--use-skewnorm-model/--no-skewnorm-model', default=True)
 @click.option('--tpe-cluster-sigma', default=15)
 @click.option('--min-tpe-reads', default=5)
 @click.option('--min-tpe-fractional-change', default=0.1)
 @click.option('-p', '--processes', default=4)
+@click.option('-r', '--random-seed', default=None)
 def d3pendr(treatment_fns, control_fns,
             output_prefix, write_apa_sites,
             annotation_gtf_fn,
@@ -41,9 +43,10 @@ def d3pendr(treatment_fns, control_fns,
             extend_gene_three_prime,
             use_locus_tag,
             max_terminal_intron_size, min_terminal_exon_size,
-            bootstraps, threshold, use_gamma_model, test_homogeneity,
+            bootstraps, threshold, use_gamma_model,
+            test_homogeneity, use_skewnorm_model,
             tpe_cluster_sigma, min_tpe_reads, min_tpe_fractional_change,
-            processes):
+            processes, random_seed):
     '''
     d3pendr: Differential 3' End analysis of Nanopore Direct RNAs
 
@@ -55,6 +58,9 @@ def d3pendr(treatment_fns, control_fns,
     Outputs bed6 format with extra columns.
     '''
 
+    if random_seed is None:
+        random_seed = abs(hash(annotation_gtf_fn))
+
     results, apa_sites = run_d3pendr(
         annotation_gtf_fn,
         treatment_fns, control_fns,
@@ -65,10 +71,10 @@ def d3pendr(treatment_fns, control_fns,
         use_locus_tag,
         max_terminal_intron_size, min_terminal_exon_size,
         bootstraps, threshold,
-        use_gamma_model, test_homogeneity,
+        use_gamma_model, test_homogeneity, use_skewnorm_model,
         write_apa_sites,
         tpe_cluster_sigma, min_tpe_reads, min_tpe_fractional_change,
-        processes
+        processes, random_seed
     )
     output_bed = f'{output_prefix}.apa_results.bed'
     write_wass_test_output_bed(output_bed, results)

--- a/d3pendr/output.py
+++ b/d3pendr/output.py
@@ -3,12 +3,14 @@ def write_wass_test_output_bed(output_bed_fn, results):
         for (
             chrom, start, end, gene_id, score, strand,
             wass_dist, wass_dir, wass_pval, wass_fdr,
+            sil_score, sil_pval, sil_fdr,
             nreads_cntrl, nreads_treat
         ) in results.itertuples(index=False):
             record = (f'{chrom}\t{int(start):d}\t{int(end):d}\t'
                       f'{gene_id}\t{int(score):d}\t{strand}\t'
                       f'{wass_dist:.1f}\t{wass_dir:.1f}\t'
                       f'{wass_pval:.3g}\t{wass_fdr:.3g}\t'
+                      f'{sil_score:.3f}\t{sil_pval:.3g}\t{sil_fdr:.3g}\t'
                       f'{sum(nreads_cntrl):d}\t{sum(nreads_treat):d}\n')
             bed.write(record)
 

--- a/d3pendr/output.py
+++ b/d3pendr/output.py
@@ -1,32 +1,26 @@
+import numpy as np
+
+def format_bed_record(row):
+    row = row.to_dict()
+    with np.errstate(divide='ignore'):
+        row['score'] = int(min(1000, -100 * np.log10(row['wass_fdr'])))
+    row['start'] = int(row['start'])
+    row['end'] = int(row['end'])
+    row['nreads_cntrl'] = int(row['nreads_cntrl'])
+    row['nreads_treat'] = int(row['nreads_treat'])
+    record = (
+        '{chrom}\t{start:d}\t{end:d}\t'
+        '{locus_id}\t{score:d}\t{strand}\t'
+        '{wass_dist:.1f}\t{wass_dir:.1f}\t'
+        '{wass_pval:.3g}\t{wass_fdr:.3g}\t'
+        '{silhouette:.3f}\t{sil_pval:.3g}\t{sil_fdr:.3g}\t'
+        '{nreads_cntrl:d}\t{nreads_treat:d}\n'
+    )
+    return record.format(**row)
+
+
 def write_wass_test_output_bed(output_bed_fn, results):
     with open(output_bed_fn, 'w') as bed:
-        for (
-            chrom, start, end, gene_id, score, strand,
-            wass_dist, wass_dir, wass_pval, wass_fdr,
-            sil_score, sil_pval, sil_fdr,
-            nreads_cntrl, nreads_treat
-        ) in results.itertuples(index=False):
-            record = (f'{chrom}\t{int(start):d}\t{int(end):d}\t'
-                      f'{gene_id}\t{int(score):d}\t{strand}\t'
-                      f'{wass_dist:.1f}\t{wass_dir:.1f}\t'
-                      f'{wass_pval:.3g}\t{wass_fdr:.3g}\t'
-                      f'{sil_score:.3f}\t{sil_pval:.3g}\t{sil_fdr:.3g}\t'
-                      f'{sum(nreads_cntrl):d}\t{sum(nreads_treat):d}\n')
-            bed.write(record)
-
-
-def write_apa_site_bed(output_bed_fn, results):
-    with open(output_bed_fn, 'w') as bed:
-        for (
-            chrom, start, end, gene_id, strand,
-            cntrl_count, treat_count,
-            cntrl_frac, treat_frac,
-            relative_change
-        ) in results.itertuples(index=False):
-            direction = int(relative_change > 0)
-            record = (f'{chrom}\t{start:d}\t{end:d}\t'
-                      f'{gene_id}\t{direction:d}\t{strand}\t'
-                      f'{cntrl_count:d}\t{treat_count:d}\t'
-                      f'{cntrl_frac:.2f}\t{treat_frac:.2f}\t'
-                      f'{relative_change:.2f}\n')
+        for _, row in results.iterrows():
+            record = format_bed_record(row)
             bed.write(record)

--- a/d3pendr/stats.py
+++ b/d3pendr/stats.py
@@ -59,22 +59,25 @@ def pairwise_wasserstein(samples):
 
 
 def silhouette_score(X, labels):
-    _, idx, label_counts = np.unique(
-        labels, return_inverse=True, return_counts=True
-    )
-    label_counts = label_counts[idx]
-    a = np.zeros(len(labels))
-    b = np.zeros(len(labels))
-    for i, j in zip(*np.triu_indices(len(labels))):
+    assert np.array_equal(np.sort(labels), labels)
+    # renumber from zero
+    unique_labels = np.unique(labels, return_inverse=True)
+    n_samples = len(labels)
+    n_labels = len(unique_labels)
+
+    idx = np.indices(X.shape).reshape(2, -1)
+    sum_ = np.zeros((n_samples, n_labels))
+    count = np.zeros((n_samples,  n_labels))
+    for i, j, r, c, d in zip(*idx, *labels[idx], X.ravel()):
         if i != j:
-            if labels[i] == labels[j]:
-                a[i] += X[i, j]
-                a[j] += X[i, j]
-            else:
-                b[i] += X[i, j]
-                b[j] += X[i, j]
-    a = a / (label_counts - 1)
-    b = b / label_counts
+            sum_[i, c] += d
+            count[i, c] += 1
+    mean = (sum_ / count).tolist()
+    a = np.empty(n_samples)
+    b = np.empty(n_samples)
+    for i, (lab, vals) in enumerate(zip(labels, mean)):
+        a[i] = vals.pop(lab)
+        b[i] = min(vals)
     return np.mean((b - a) / np.maximum(a, b))
 
 

--- a/d3pendr/stats.py
+++ b/d3pendr/stats.py
@@ -11,15 +11,15 @@ def wasserstein_distance_and_direction(u_values, v_values):
     v_sorter = np.argsort(v_values)
 
     all_values = np.concatenate((u_values, v_values))
-    all_values.sort(kind='mergesort')
+    all_values = np.sort(all_values)
 
     # Compute the differences between pairs of successive values of u and v.
     deltas = np.diff(all_values)
 
     # Get the respective positions of the values of u and v among the values of
     # both distributions.
-    u_cdf_indices = u_values[u_sorter].searchsorted(all_values[:-1], 'right')
-    v_cdf_indices = v_values[v_sorter].searchsorted(all_values[:-1], 'right')
+    u_cdf_indices = np.searchsorted(u_values[u_sorter], all_values[:-1], 'right')
+    v_cdf_indices = np.searchsorted(v_values[v_sorter], all_values[:-1], 'right')
 
     # Calculate the CDFs of u and v
     u_cdf = u_cdf_indices / u_values.size
@@ -32,7 +32,63 @@ def wasserstein_distance_and_direction(u_values, v_values):
     return np.sum(np.abs(mag)), np.sum(mag)
 
 
-def wasserstein_test(u_values, v_values, bootstraps=999, use_gamma_model=True):
+def pairwise_wasserstein(samples):
+    dist_mat = np.empty(shape=(len(samples), len(samples)))
+    for i, j in zip(*np.triu_indices(len(samples))):
+        if i == j:
+            dist_mat[i, j] = 0
+        else:
+            wass, _ = wasserstein_distance_and_direction(samples[i], samples[j])
+            dist_mat[i, j] = wass
+            dist_mat[j, i] = wass
+    return dist_mat
+
+
+def wasserstein_silhouette_test(cntrl, treat, bootstraps=999,
+                                fit_skewnorm=True, fit_gamma=True,
+                                random_state=None):
+    rs = np.random.RandomState(random_state)
+    wass_dist, wass_dir = wasserstein_distance_and_direction(
+        np.concatenate(cntrl),
+        np.concatenate(treat)
+    )
+    labels = np.repeat([0, 1], [len(cntrl), len(treat)])
+    pool = cntrl + treat
+    obs_dist_mat = pairwise_wasserstein(pool)
+    sil = silhouette_score(obs_dist_mat, labels)
+    samp_lns = [len(samp) for samp in pool]
+    split_idx = np.cumsum(samp_lns[:-1])
+    n = split_idx[len(cntrl) - 1]
+    pool = np.concatenate(pool)
+    exp_wass = []
+    exp_sil = []
+    for _ in range(bootstraps):
+        rs.shuffle(pool)
+        exp_wass.append(stats.wasserstein_distance(pool[:n], pool[n:]))
+        shuf_samps = np.array_split(pool, split_idx)
+        exp_dist_mat = pairwise_wasserstein(shuf_samps)
+        exp_sil.append(silhouette_score(exp_dist_mat, labels))
+    exp_wass = np.array(exp_wass)
+    exp_sil = np.array(exp_sil)
+
+    if fit_gamma:
+        g_fit = stats.gamma.fit(exp_wass)
+        wass_pval = stats.gamma.sf(wass_dist, *g_fit)
+    else:
+        wass_pval = ((exp >= wass_dist).sum() + 1) / (bootstraps + 1)
+
+    if fit_skewnorm:
+        s_fit = stats.skewnorm.fit(exp_sil)
+        sil_pval = stats.skewnorm.sf(sil, *s_fit)
+    else:
+        sil_pval = ((sil <= exp_sil).sum() + 1) / (bootstraps + 1)
+    return wass_dist, wass_dir, wass_pval, sil, sil_pval
+
+
+def wasserstein_test(u_values, v_values, bootstraps=999,
+                     fit_gamma=True, random_state=None):
+
+    rs = np.random.RandomState(random_state)
     # permutation test of wasserstein distance
     # based on the one outlined in https://github.com/cdowd/twosamples
     wass_dist, wass_dir = wasserstein_distance_and_direction(u_values, v_values)
@@ -44,67 +100,36 @@ def wasserstein_test(u_values, v_values, bootstraps=999, use_gamma_model=True):
     n = len(u_values)
     exp = []
     for _ in range(bootstraps):
-        np.random.shuffle(pool)
+        rs.shuffle(pool)
         exp.append(stats.wasserstein_distance(pool[:n], pool[n:]))
     exp = np.array(exp)
 
-    if not use_gamma_model:
+    if fit_gamma:
+        # fit a gamma distribution to the expected distances
+        g_fit = stats.gamma.fit(exp_wass)
+        # compute p value using survival function
+        wass_p_val = stats.gamma.sf(wass_dist, *g_fit)
+    else:
         # bootstrap p value with pseudocount
         p_val = ((exp >= wass_dist).sum() + 1) / (bootstraps + 1)
-    else:
-        # fit a gamma distribution to the expected distances
-        g = stats.gamma(*stats.gamma.fit(exp))
-        # compute p value using survival function
-        p_val = g.sf(wass_dist)
-    return wass_dist, wass_dir, p_val
-
-
-def wasserstein_test_with_replicates(u_values, v_values,
-                                     bootstraps=999,
-                                     threshold=0.05,
-                                     use_gamma_model=True,
-                                     test_homogeneity=False):
-    # first pool replicates and perform normal wass test
-    u_pooled = np.concatenate(u_values)
-    v_pooled = np.concatenate(v_values)
-    wass_dist, wass_dir, p_val = wasserstein_test(
-        u_pooled, v_pooled, bootstraps=bootstraps, use_gamma_model=use_gamma_model
-    )
-
-    # we only bother testing for homogeneity of replicates if the test between
-    # replicates is significant
-    if test_homogeneity and p_val <= threshold:
-
-        # produce pairwise distances between replicates for both conditions
-        u_self_wass = np.array(
-            [stats.wasserstein_distance(u_i, u_j)
-             for u_i, u_j in it.combinations(u_values, r=2)]
-        )
-        v_self_wass = np.array(
-            [stats.wasserstein_distance(v_i, v_j)
-             for v_i, v_j in it.combinations(v_values, r=2)]
-        )
-
-        # samples are considered homogeneous if the distance between the two
-        # conds is greater than all the pairwise distances within conds.
-        is_homogeneous = 1 - int((u_self_wass >= wass_dist).any() |
-                                 (v_self_wass >= wass_dist).any())
-        if not is_homogeneous:
-            p_val = 1
     return wass_dist, wass_dir, p_val
 
 
 def d3pendr_stats(tpe_dist_cntrl, tpe_dist_treat,
-                  bootstraps=999, threshold=0.05,
-                  use_gamma_model=True, test_homogeneity=False):
-    if len(tpe_dist_cntrl) == 1:
+                  bootstraps=999, fit_gamma=True,
+                  sil_test=True, fit_skewnorm=True,
+                  random_state=None):
+    if len(tpe_dist_cntrl) == 1 or not sil_test:
         wass_dist, wass_dir, wass_pval = wasserstein_test(
-            tpe_dist_cntrl[0], tpe_dist_treat[0], bootstraps, use_gamma_model,
+            np.concatenate(tpe_dist_cntrl),
+            np.concatenate(tpe_dist_treat),
+            bootstraps, fit_gamma, random_state
         )
+        sil, sil_pval = np.nan, np.nan
     else:
-        wass_dist, wass_dir, wass_pval = wasserstein_test_with_replicates(
+        wass_dist, wass_dir, wass_pval, sil, sil_pval = wasserstein_silhouette_test(
             tpe_dist_cntrl, tpe_dist_treat, bootstraps,
-            threshold, use_gamma_model, test_homogeneity,
+            fit_gamma, fit_skewnorm, random_state
         )
 
-    return wass_dist, wass_dir, wass_pval
+    return wass_dist, wass_dir, wass_pval, sil, sil_pval


### PR DESCRIPTION
Introduces a new method for significance testing that does not require pooling of replicates:

* Replicates within and between conditions are compared with EMD to create distance matrix
* Distance matrix and control/treatment labels are used to assess clustering using silhouette
* Reads are permuted between replicates and conditions, and distance matrix/silhouette recomputed
* Null distribution of silhouette scores is fitted with skewed normal distribution, p value estimated.

todo: testing, documentation! 